### PR TITLE
Async and reduced dependencies 

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 
 const args = process.argv.slice(2);
-if (args.length != 2) {
+if (args.length !== 2) {
 	console.error('copy-modules requires 2 parameters: projectPath and targetPath');
-	return 1;
-} else {
-	require('../index').execute(...args);
+	process.exit(1);
 }
 
+require('../index').execute(...args)
+	.then(() => process.exit(0))
+	.catch(e => {
+		console.error(e);
+		process.exit(1);
+	});

--- a/index.js
+++ b/index.js
@@ -1,16 +1,22 @@
 const copier = {};
 module.exports = copier;
 
-const _ = require('lodash');
+const get = require('lodash.get');
 require('colors');
 const fs = require('fs-extra');
 const path = require('path');
 const NODE_MODULES = 'node_modules';
 
-copier.execute = (projectPath, targetPath) => {
-	if (_.isNil(projectPath)) {
+/**
+ * @param {string} projectPath absolute filepath for project root directory
+ * @param {string} targetPath absolute filepath for target directory to copy node_modules into
+ * @returns {Promise<void>}
+ */
+copier.execute = async (projectPath, targetPath) => {
+	if (projectPath === null) {
 		throw new Error('projectPath must be defined.');
-	} else if (_.isNil(targetPath)) {
+	}
+	if (targetPath === null) {
 		throw new Error('targetPath must be defined.');
 	}
 
@@ -20,30 +26,47 @@ copier.execute = (projectPath, targetPath) => {
 
 	let packageJson;
 	try {
-		packageJson = require(path.join(projectPath, 'package.json'));
+		packageJson = await fs.readJson(path.join(projectPath, 'package.json'));
 	} catch (err) {
 		console.error(err);
-		return new Error(`Cannot load package.json file: ${path.join(projectPath, 'package.json')}`);
+		throw new Error(`Cannot load package.json file: ${path.join(projectPath, 'package.json')}`);
 	}
 
 	const dependencies = packageJson && packageJson.dependencies;
+	const directoriesToBeCopied = gatherDirectoriesToCopy(projectPath, Object.keys(dependencies));
+	console.debug(`directoriesToBeCopied: ${JSON.stringify(directoriesToBeCopied, null, 2)}`.blue);
 
+	return Promise.all(directoriesToBeCopied.map(async directory => {
+		const destPath = path.join(targetPath, directory.substring(projectPath.length));
+		console.debug(`copying to directory: ${destPath}`);
+		return fs.copy(directory, destPath, { overwrite: true });
+	}));
+};
+
+// FIXME: Use an actual Set to ensure no duplicates?
+/**
+ * Gathers the full listing of directories we need to copy
+ * @param {string} projectPath absolute path to source project root directory
+ * @param {string[]} dependencies array of module ids to be copied
+ * @returns {string[]} set of directories to copy
+ */
+function gatherDirectoriesToCopy(projectPath, dependencies) {
 	const directoriesToBeCopied = [];
 	const directoriesFound = [];
 
-	const pendingItems = _.keys(dependencies).map(name => ({ name }));
+	const pendingItems = dependencies.map(name => ({ name }));
 
 	while (pendingItems.length) {
 		const currentItem = pendingItems.shift();
 		console.debug(`searching for module: ${currentItem.name}`.blue);
 		const dependency = findDependency(currentItem);
-		if (dependency && ! _.includes(directoriesFound, dependency.directory)) {
+		if (dependency && !directoriesFound.includes(dependency.directory)) {
 			directoriesFound.push(dependency.directory);
-			if (dependency.isRoot && ! _.includes(directoriesToBeCopied, dependency.directory)) {
+			if (dependency.isRoot && !directoriesToBeCopied.includes(dependency.directory)) {
 				directoriesToBeCopied.push(dependency.directory);
 				console.debug(`    adding dependency: ${dependency.name}`);
 			}
-			_.forEach(dependency.dependencies, subDependency => {
+			dependency.dependencies.forEach(subDependency => {
 				pendingItems.push({
 					name:   subDependency,
 					parent: {
@@ -54,36 +77,40 @@ copier.execute = (projectPath, targetPath) => {
 			});
 		}
 	}
-	console.debug(`directoriesToBeCopied: ${JSON.stringify(directoriesToBeCopied, null, 2)}`.blue);
+	return directoriesToBeCopied;
 
-	_.forEach(directoriesToBeCopied, directory => {
-		const destPath = path.join(targetPath, directory.substring(projectPath.length));
-		console.debug(`copying to directory: ${destPath}`);
-		fs.copySync(directory, destPath, { overwrite: true });
-	});
-
+	/**
+	 * @param {object} metadata module metadata
+	 * @param {string} [name] module name
+	 * @returns {object} module metadata
+	 */
 	function findDependency(metadata, name) {
-		if (_.isNil(metadata)) {
+		if (metadata === null) {
 			return null;
 		}
 		name = name || metadata.name;
-		const parentDir = _.get(metadata, 'parent.directory', projectPath);
+		const parentDir = get(metadata, 'parent.directory', projectPath);
 		const directory = path.join(parentDir, NODE_MODULES, name);
 		console.debug(`    looking in dir: ${directory}`);
 		let dependencyPackageJson;
 		try {
-			dependencyPackageJson = require(path.join(directory, 'package.json'));
+			dependencyPackageJson = fs.readJsonSync(path.join(directory, 'package.json'));
 		} catch (err) {
 			console.debug(`     error: ${directory}`.red);
 			return findDependency(metadata.parent, name);
 		}
 		console.debug('    found module!'.green);
+		const dependencies = Object.keys(dependencyPackageJson.dependencies || {});
+		// include optional dependencies too
+		if (dependencyPackageJson.optionalDependencies) {
+			dependencies.push(...Object.keys(dependencyPackageJson.optionalDependencies));
+		}
 		return {
 			name,
 			directory,
-			dependencies: _.keys(dependencyPackageJson.dependencies),
-			isRoot:       projectPath === parentDir,
+			dependencies,
+			isRoot: projectPath === parentDir,
 		};
 	}
-};
+}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -807,11 +807,6 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@titanium/module-copier",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -804,7 +804,13 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "mimic-fn": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	"dependencies": {
 		"colors": "^1.3.3",
 		"fs-extra": "^7.0.1",
-		"lodash": "^4.17.11"
+		"lodash.get": "^4.4.2"
 	},
 	"bin": {
 		"copymodules": "./bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
 	},
 	"dependencies": {
 		"colors": "^1.3.3",
-		"fs-extra": "^7.0.1",
-		"lodash.get": "^4.4.2"
+		"fs-extra": "^7.0.1"
 	},
 	"bin": {
 		"copymodules": "./bin/cli.js"


### PR DESCRIPTION
I'm using this as a POC for eventually hooking straight into the CLI builds. In testing some approaches locally against the SDK's package.json/node_modules this solution worked pretty well (much faster than a naive copy all of `node_modules` and then running `npm prune --production` afterwards).

This PR moves to an async version with reduced dependencies. In my testing, this drove the time from ~7.7s to ~2.8s. (For reference the naive version was like ~33s!)

Not that the major parallelization was done in copying the directories, I didn't attempt to parallelize the gathering of the unique set of dependency directories. I assume a tiny bit more performance may be able to be found there.